### PR TITLE
LinearAlgebra compat doesn't work with Julia 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Trace = "afc56b53-c9a9-482a-a956-d1d800e05558"
 [compat]
 Colors = "0.12.11"
 GeometryBasics = "0.4.11"
-LinearAlgebra = "1.11.0"
+LinearAlgebra = "1"
 Makie = "0.21"
 julia = "1.6.7"
 


### PR DESCRIPTION
This relaxes that compat requirement